### PR TITLE
fix: secure external link

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
          class="w-full max-w-2xl mx-auto rounded-xl shadow-xl" />
     <div class="mt-6">
       <a href="https://pancakeswap.finance/swap?outputCurrency=0x3c841c88d3819c901ec0fe29897146dca509552b"
-         target="_blank" class="button-buy inline-block">
+         target="_blank" rel="noopener noreferrer" class="button-buy inline-block">
         Buy BEL on PancakeSwap
       </a>
     </div>


### PR DESCRIPTION
## Summary
- add noopener noreferrer to external PancakeSwap link to prevent malicious tab manipulation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68915788c0a083319cbd0b20d4cdfda6